### PR TITLE
fix np.float

### DIFF
--- a/GAMs/PyGAM/pid.py
+++ b/GAMs/PyGAM/pid.py
@@ -28,9 +28,9 @@ pygam.ParameterDict['pid'] = {
 
 #Past history required for pid 
 global y_1, x_1, x_2, x_fact, x_1_fact, x_2_fact
-y_1 = np.float(0.)
-x_1 = np.float(0.)
-x_2 = np.float(0.)
+y_1 = float(0.)
+x_1 = float(0.)
+x_2 = float(0.)
 #PID factors in Z, computed once for all
 x_fact = 0
 x_1_fact = 0
@@ -48,9 +48,9 @@ def setup():
     print('Kd: '+str(Kd))    
     print('T: '+str(T))    
 
-    x_fact = np.float(Kp + T*Ki + Kd/T)
-    x_1_fact = np.float(-(Kp+2.*Kd/T))
-    x_2_fact = np.float(Kd/T)
+    x_fact = float(Kp + T*Ki + Kd/T)
+    x_1_fact = float(-(Kp+2.*Kd/T))
+    x_2_fact = float(Kd/T)
 
 def execute(x):
     global y_1


### PR DESCRIPTION
Before this change, we get the following error on modern NumPy versions:

```
Traceback (most recent call last):
  File "/usr/local/mdsplus/tdi/dev_support/MDSDEVICES.py", line 69, in MDSDEVICES
    ans += importDevices(module)
  File "/usr/local/mdsplus/tdi/dev_support/MDSDEVICES.py", line 40, in importDevices
    module = __import__(name)
  File "/usr/local/mdsplus/pydevices/RfxDevices/__init__.py", line 67, in <module>
    _mimport(filename[:-3])
  File "/usr/local/mdsplus/pydevices/RfxDevices/__init__.py", line 42, in _mimport
    module = __import__(name, globals(), level=level)
  File "/usr/local/mdsplus/pydevices/RfxDevices/MARTE2_PYTHON_PID.py", line 29, in <module>
    import pid
  File "/opt/MARTe2/MARTe2-MDSplus/GAMs/PyGAM/pid.py", line 31, in <module>
    y_1 = np.float(0.)
  File "/home/jdanz/.local/lib/python3.8/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

This commit resolves that error.